### PR TITLE
Center button in tagslist layout

### DIFF
--- a/flixable.php
+++ b/flixable.php
@@ -1396,12 +1396,12 @@ $svg_placeholder = 'data:image/svg+xml;base64,' . base64_encode(
             <?php } wp_reset_query(); ?>
         </div>
         <!-- show selected categories -->
-		
-		
-		<?php if (get_sub_field('button')): ?>
-   
-	<a href="<?php $link = get_sub_field('link'); if ($link) echo esc_html($link); ?>" class="my-3 btn btn-primary"><?php $button = get_sub_field('button'); if ($button) echo esc_html($button); ?></a>
-	
+
+
+                <?php if (get_sub_field('button')): ?>
+                <div class="text-center">
+        <a href="<?php $link = get_sub_field('link'); if ($link) echo esc_html($link); ?>" class="my-3 btn btn-primary"><?php $button = get_sub_field('button'); if ($button) echo esc_html($button); ?></a>
+                </div>
 <?php endif; ?>
 
 
@@ -1970,10 +1970,10 @@ if ($addmore) { // Code to display if the addmore checkbox is checked
 <?php elseif( get_row_layout() == 'postsrelatedcatslider' ): ?>
 
 
-<div class="postsrelatedtagslider py-spacer bg-light">
+<div class="postsrelatedtagslider py-spacer bg-secondary">
 
 <div class="text-center">
-<h3 class="fs-1 fw-bold" ><?php $title = get_sub_field('title'); if ($title) echo esc_html($title); ?></h3>
+<h3 class="fs-1 fw-bold text-white" ><?php $title = get_sub_field('title'); if ($title) echo esc_html($title); ?></h3>
 <p class="mt-4 mb-3"><?php $subtitle = get_sub_field('subtitle'); if ($subtitle) echo esc_html($subtitle); ?></p>
 </div>  
 

--- a/footer.php
+++ b/footer.php
@@ -590,12 +590,18 @@ blockquote p {margin:1rem 0}
 }
 
 
-.postsrelatedtagslider .carousel-indicators .active, .testimonial .carousel-indicators .active, .articleimages  .carousel-indicators active, .pagecontent9 .carousel-indicators active {
-    background-color: black; /* Change the active indicator to black */
+.postsrelatedtagslider .carousel-indicators .active {
+    background-color: #fff; /* Use white for the active indicator */
+}
+.testimonial .carousel-indicators .active, .articleimages  .carousel-indicators active, .pagecontent9 .carousel-indicators active {
+    background-color: black; /* Retain black for other sliders */
 }
 
-.postsrelatedtagslider .carousel-indicators li, .testimonial .carousel-indicators li, .articleimages  .carousel-indicators li, .pagecontent9 .carousel-indicators li   {
-    background-color: rgba(0, 0, 0, 1); /* Change the inactive indicators to a semi-transparent black */
+.postsrelatedtagslider .carousel-indicators li {
+    background-color: rgba(255, 255, 255, 0.5); /* Light gray for inactive indicators */
+}
+.testimonial .carousel-indicators li, .articleimages  .carousel-indicators li, .pagecontent9 .carousel-indicators li   {
+    background-color: rgba(0, 0, 0, 1); /* Keep other indicators black */
 }
 	
 	.postsrelatedtagslider .carousel-item img, .testimonial .carousel-item img {


### PR DESCRIPTION
## Summary
- wrap the tagslist button with a `text-center` div so it centers horizontally
- color postsrelatedtagslider background secondary and title white
- switch postsrelatedtagslider carousel indicators to white

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856aa73b37c8333b3de19ef98ad6c70