### PR TITLE
Fix slider title color

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -361,6 +361,10 @@ h1,h2,h3,h4,h5,h6 {font-weight:600 !important}
       a, .page-link, .text-primary, .dropdown .text-primary, .dropdown button  { color: <?php $Color = get_field('Color', 2); if ($Color) echo esc_html($Color); ?> !important;}
       
   .text-secondary {color: var(--bs-primary) !important}
+  /* Ensure the slider titles use the primary color */
+  .postsrelatedtagslider .text-secondary {
+    color: var(--bs-primary) !important;
+  }
   
 
   


### PR DESCRIPTION
## Summary
- ensure `.postsrelatedtagslider` titles use the primary theme color

## Testing
- `php -l footer.php`

------
https://chatgpt.com/codex/tasks/task_e_6857b62fcd088333aa674e3a99506630